### PR TITLE
Adapt to asset descriptor changes

### DIFF
--- a/Sources/Safehill-Client/Models/Assets/AssetDescriptorGroupInfo.swift
+++ b/Sources/Safehill-Client/Models/Assets/AssetDescriptorGroupInfo.swift
@@ -5,4 +5,6 @@ public protocol SHAssetGroupInfo {
     var name: String? { get }
     /// ISO8601 formatted datetime, representing the time the asset group was created
     var createdAt: Date? { get }
+    /// Whether or not this group was created from a thread
+    var isPhotoMessageGroup: Bool { get }
 }

--- a/Sources/Safehill-Client/Models/Assets/AssetDescriptorSharingInfo.swift
+++ b/Sources/Safehill-Client/Models/Assets/AssetDescriptorSharingInfo.swift
@@ -3,15 +3,15 @@ import Foundation
 public protocol SHDescriptorSharingInfo {
     var sharedByUserIdentifier: String { get }
     /// Maps user public identifiers to asset group identifiers
-    var sharedWithUserIdentifiersInGroup: [UserIdentifier: String] { get }
+    var groupIdsByRecipientUserIdentifier: [UserIdentifier: [String]] { get }
     var groupInfoById: [String: SHAssetGroupInfo] { get }
 }
 
 public extension SHDescriptorSharingInfo {
-    func userSharingInfo(for userId: String) -> SHAssetGroupInfo? {
-        if let groupId = self.sharedWithUserIdentifiersInGroup[userId] {
-            return self.groupInfoById[groupId]
+    func userSharingInfo(for userId: String) -> [SHAssetGroupInfo] {
+        if let groupIds = self.groupIdsByRecipientUserIdentifier[userId] {
+            return groupIds.compactMap { self.groupInfoById[$0] }
         }
-        return nil
+        return []
     }
 }

--- a/Sources/Safehill-Client/Models/Assets/AssetDescriptorsDiff.swift
+++ b/Sources/Safehill-Client/Models/Assets/AssetDescriptorsDiff.swift
@@ -119,26 +119,30 @@ struct AssetDescriptorsDiff {
                 continue
             }
             
-            for (userId, groupId) in remoteDescriptor.sharingInfo.sharedWithUserIdentifiersInGroup {
-                if correspondingLocalDescriptor.sharingInfo.sharedWithUserIdentifiersInGroup[userId] == nil {
-                    if userIdsToAddToSharesByAssetGid[correspondingLocalDescriptor.globalIdentifier] == nil 
+            for (userId, groupIds) in remoteDescriptor.sharingInfo.groupIdsByRecipientUserIdentifier {
+                guard let groupId = groupIds.first else {
+                    continue
+                }
+                if correspondingLocalDescriptor.sharingInfo.groupIdsByRecipientUserIdentifier[userId] == nil {
+                    if userIdsToAddToSharesByAssetGid[correspondingLocalDescriptor.globalIdentifier] == nil
                     {
                         let remoteDescGroupInfo = remoteDescriptor.sharingInfo.groupInfoById[groupId]
                         if remoteDescGroupInfo == nil {
-                            log.warning("group info missing for group \(groupId) in descriptor of \(remoteDescriptor.globalIdentifier). sharedWithUserIdentifiersInGroup=\(remoteDescriptor.sharingInfo.sharedWithUserIdentifiersInGroup)")
+                            log.warning("group info missing for group \(groupId) in descriptor of \(remoteDescriptor.globalIdentifier). groupIdsByRecipientUserIdentifier=\(remoteDescriptor.sharingInfo.groupIdsByRecipientUserIdentifier)")
                         }
                         userIdsToAddToSharesByAssetGid[correspondingLocalDescriptor.globalIdentifier] = (
                             from: correspondingLocalDescriptor.sharingInfo.sharedByUserIdentifier,
                             groupIdByRecipientId: [userId: groupId],
                             groupInfoById: [groupId: SHGenericAssetGroupInfo(
                                 name: remoteDescGroupInfo?.name,
-                                createdAt: remoteDescGroupInfo?.createdAt
+                                createdAt: remoteDescGroupInfo?.createdAt,
+                                isPhotoMessageGroup: remoteDescGroupInfo?.isPhotoMessageGroup ?? false
                             )]
                         )
                     } else {
                         let remoteDescGroupInfo = remoteDescriptor.sharingInfo.groupInfoById[groupId]
                         if remoteDescGroupInfo == nil {
-                            log.warning("group info missing for group \(groupId) in descriptor of \(remoteDescriptor.globalIdentifier). sharedWithUserIdentifiersInGroup=\(remoteDescriptor.sharingInfo.sharedWithUserIdentifiersInGroup)")
+                            log.warning("group info missing for group \(groupId) in descriptor of \(remoteDescriptor.globalIdentifier). groupIdsByRecipientUserIdentifier=\(remoteDescriptor.sharingInfo.groupIdsByRecipientUserIdentifier)")
                         }
                         
                         var newDict = userIdsToAddToSharesByAssetGid[correspondingLocalDescriptor.globalIdentifier]!.groupIdByRecipientId
@@ -147,7 +151,8 @@ struct AssetDescriptorsDiff {
                         var newGroupInfoDict = userIdsToAddToSharesByAssetGid[correspondingLocalDescriptor.globalIdentifier]!.groupInfoById
                         newGroupInfoDict[groupId] = SHGenericAssetGroupInfo(
                             name: newGroupInfoDict[groupId]?.name ?? remoteDescGroupInfo?.name,
-                            createdAt: newGroupInfoDict[groupId]?.createdAt ?? remoteDescGroupInfo?.createdAt
+                            createdAt: newGroupInfoDict[groupId]?.createdAt ?? remoteDescGroupInfo?.createdAt,
+                            isPhotoMessageGroup: newGroupInfoDict[groupId]?.isPhotoMessageGroup ?? remoteDescGroupInfo?.isPhotoMessageGroup ?? false
                         )
                         
                         userIdsToAddToSharesByAssetGid[correspondingLocalDescriptor.globalIdentifier] = (
@@ -184,16 +189,21 @@ struct AssetDescriptorsDiff {
                 continue
             }
             
-            for (userId, groupId) in localDescriptor.sharingInfo.sharedWithUserIdentifiersInGroup {
-                if remoteDescriptor.sharingInfo.sharedWithUserIdentifiersInGroup[userId] == nil {
-                    if userIdsToRemoveFromSharesByAssetGid[localDescriptor.globalIdentifier] == nil 
+            for (userId, groupIds) in localDescriptor.sharingInfo.groupIdsByRecipientUserIdentifier {
+                guard let groupId = groupIds.first else {
+                    continue
+                }
+                
+                if remoteDescriptor.sharingInfo.groupIdsByRecipientUserIdentifier[userId] == nil {
+                    if userIdsToRemoveFromSharesByAssetGid[localDescriptor.globalIdentifier] == nil
                     {
                         userIdsToRemoveFromSharesByAssetGid[localDescriptor.globalIdentifier] = (
                             from: localDescriptor.sharingInfo.sharedByUserIdentifier,
                             groupIdByRecipientId: [userId: groupId],
                             groupInfoById: [groupId: SHGenericAssetGroupInfo(
                                 name: remoteDescriptor.sharingInfo.groupInfoById[groupId]?.name,
-                                createdAt: remoteDescriptor.sharingInfo.groupInfoById[groupId]?.createdAt
+                                createdAt: remoteDescriptor.sharingInfo.groupInfoById[groupId]?.createdAt,
+                                isPhotoMessageGroup: remoteDescriptor.sharingInfo.groupInfoById[groupId]?.isPhotoMessageGroup ?? false
                             )]
                         )
                     } else {
@@ -203,7 +213,8 @@ struct AssetDescriptorsDiff {
                         var newGroupInfoDict = userIdsToRemoveFromSharesByAssetGid[localDescriptor.globalIdentifier]!.groupInfoById
                         newGroupInfoDict[groupId] = SHGenericAssetGroupInfo(
                             name: remoteDescriptor.sharingInfo.groupInfoById[groupId]?.name,
-                            createdAt: remoteDescriptor.sharingInfo.groupInfoById[groupId]?.createdAt
+                            createdAt: remoteDescriptor.sharingInfo.groupInfoById[groupId]?.createdAt,
+                            isPhotoMessageGroup: remoteDescriptor.sharingInfo.groupInfoById[groupId]?.isPhotoMessageGroup ?? false
                         )
                         
                         userIdsToRemoveFromSharesByAssetGid[localDescriptor.globalIdentifier] = (

--- a/Sources/Safehill-Client/Models/Assets/GenericAssetDescriptor.swift
+++ b/Sources/Safehill-Client/Models/Assets/GenericAssetDescriptor.swift
@@ -60,7 +60,7 @@ public struct SHGenericAssetDescriptor : SHAssetDescriptor, Codable {
             uploadState: self.uploadState,
             sharingInfo: SHGenericDescriptorSharingInfo(
                 sharedByUserIdentifier: self.sharingInfo.sharedByUserIdentifier,
-                sharedWithUserIdentifiersInGroup: self.sharingInfo.sharedWithUserIdentifiersInGroup,
+                groupIdsByRecipientUserIdentifier: self.sharingInfo.groupIdsByRecipientUserIdentifier,
                 groupInfoById: self.sharingInfo.groupInfoById
             )
         )

--- a/Sources/Safehill-Client/Models/Assets/GenericAssetDescriptorGroupInfo.swift
+++ b/Sources/Safehill-Client/Models/Assets/GenericAssetDescriptorGroupInfo.swift
@@ -3,16 +3,20 @@ import Foundation
 public struct SHGenericAssetGroupInfo : SHAssetGroupInfo, Codable {
     public let name: String?
     public let createdAt: Date?
+    public let isPhotoMessageGroup: Bool
     
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        name = try? container.decode(String?.self, forKey: .name)
-        let dateString = try? container.decode(String?.self, forKey: .createdAt)
+        name = try? container.decode(String.self, forKey: .name)
+        let dateString = try? container.decode(String.self, forKey: .createdAt)
         createdAt = dateString?.iso8601withFractionalSeconds
+        let bool = try? container.decode(Bool.self, forKey: .isPhotoMessageGroup)
+        isPhotoMessageGroup = bool ?? false
     }
     
-    init(name: String?, createdAt: Date?) {
+    init(name: String?, createdAt: Date?, isPhotoMessageGroup: Bool) {
         self.name = name
         self.createdAt = createdAt
+        self.isPhotoMessageGroup = isPhotoMessageGroup
     }
 }

--- a/Sources/Safehill-Client/Models/Assets/GenericAssetDescriptorSharingInfo.swift
+++ b/Sources/Safehill-Client/Models/Assets/GenericAssetDescriptorSharingInfo.swift
@@ -2,34 +2,34 @@ import Foundation
 
 public struct SHGenericDescriptorSharingInfo : SHDescriptorSharingInfo, Codable {
     public let sharedByUserIdentifier: String
-    public let sharedWithUserIdentifiersInGroup: [UserIdentifier: String]
+    public let groupIdsByRecipientUserIdentifier: [UserIdentifier : [String]]
     public let groupInfoById: [String: SHAssetGroupInfo]
     
     enum CodingKeys: String, CodingKey {
         case sharedByUserIdentifier
-        case sharedWithUserIdentifiersInGroup
+        case groupIdsByRecipientUserIdentifier
         case groupInfoById
     }
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(sharedByUserIdentifier, forKey: .sharedByUserIdentifier)
-        try container.encode(sharedWithUserIdentifiersInGroup, forKey: .sharedWithUserIdentifiersInGroup)
+        try container.encode(groupIdsByRecipientUserIdentifier, forKey: .groupIdsByRecipientUserIdentifier)
         try container.encode(groupInfoById as! [String: SHGenericAssetGroupInfo], forKey: .groupInfoById)
     }
     
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         sharedByUserIdentifier = try container.decode(String.self, forKey: .sharedByUserIdentifier)
-        sharedWithUserIdentifiersInGroup = try container.decode([String: String].self, forKey: .sharedWithUserIdentifiersInGroup)
+        groupIdsByRecipientUserIdentifier = try container.decode([String: [String]].self, forKey: .groupIdsByRecipientUserIdentifier)
         groupInfoById = try container.decode([String: SHGenericAssetGroupInfo].self, forKey: .groupInfoById)
     }
     
     public init(sharedByUserIdentifier: String,
-                sharedWithUserIdentifiersInGroup: [String: String],
+                groupIdsByRecipientUserIdentifier: [String: [String]],
                 groupInfoById: [String: SHAssetGroupInfo]) {
         self.sharedByUserIdentifier = sharedByUserIdentifier
-        self.sharedWithUserIdentifiersInGroup = sharedWithUserIdentifiersInGroup
+        self.groupIdsByRecipientUserIdentifier = groupIdsByRecipientUserIdentifier
         self.groupInfoById = groupInfoById
     }
 }

--- a/Sources/Safehill-Client/Models/DB/ShareGraph.swift
+++ b/Sources/Safehill-Client/Models/DB/ShareGraph.swift
@@ -21,7 +21,7 @@ public struct SHKGQuery {
         // TODO: We need support for writebatch (transaction) in KGGraph. DB writes in a for loop is never a good idea
         for descriptor in descriptors {
             do {
-                var allReceivers = Set(descriptor.sharingInfo.sharedWithUserIdentifiersInGroup.keys)
+                var allReceivers = Set(descriptor.sharingInfo.groupIdsByRecipientUserIdentifier.keys)
                 allReceivers.insert(receiverUserId)
                 try self.ingestShare(
                     of: descriptor.globalIdentifier,

--- a/Sources/Safehill-Client/Models/UserActivities/QueueItems/DownloadRequestQueueItem.swift
+++ b/Sources/Safehill-Client/Models/UserActivities/QueueItems/DownloadRequestQueueItem.swift
@@ -42,7 +42,10 @@ public class SHDownloadRequestQueueItem: NSObject, NSSecureCoding, SHSerializabl
         self.receiverUserIdentifier = receiverUserIdentifier
         
         /// The relevant group id is the group id used to share this asset with the receiver
-        for (userId, groupId) in self.assetDescriptor.sharingInfo.sharedWithUserIdentifiersInGroup {
+        for (userId, groupIds) in self.assetDescriptor.sharingInfo.groupIdsByRecipientUserIdentifier {
+            guard let groupId = groupIds.first else {
+                continue
+            }
             if userId == receiverUserIdentifier {
                 self.groupId = groupId
                 return

--- a/Sources/Safehill-Client/Network/LocalServer+Migrations.swift
+++ b/Sources/Safehill-Client/Network/LocalServer+Migrations.swift
@@ -189,7 +189,7 @@ extension LocalServer {
                             let assetGid = remoteDescriptor.globalIdentifier
                             
                             if assetToUsers[assetGid] == nil {
-                                let recipients = Array(remoteDescriptor.sharingInfo.sharedWithUserIdentifiersInGroup.keys)
+                                let recipients = Array(remoteDescriptor.sharingInfo.groupIdsByRecipientUserIdentifier.keys)
                                 log.info("[graph-sync] missing triples from <asset:\(assetGid)> <from:\(sender)> <to:\(recipients)>")
                                 if dryRun == false {
                                     try SHKGQuery.ingestShare(

--- a/Sources/Safehill-Client/Network/ServerProxy.swift
+++ b/Sources/Safehill-Client/Network/ServerProxy.swift
@@ -242,7 +242,7 @@ extension SHServerProxy {
         var userIdsSet = Set<String>()
         for descriptor in descriptors {
             userIdsSet.insert(descriptor.sharingInfo.sharedByUserIdentifier)
-            descriptor.sharingInfo.sharedWithUserIdentifiersInGroup.keys.forEach({ userIdsSet.insert($0) })
+            descriptor.sharingInfo.groupIdsByRecipientUserIdentifier.keys.forEach({ userIdsSet.insert($0) })
         }
         userIdsSet.remove(self.remoteServer.requestor.identifier)
         let userIds = Array(userIdsSet)

--- a/Sources/Safehill-Client/Tasks/Syncing/AssetsSyncOperation.swift
+++ b/Sources/Safehill-Client/Tasks/Syncing/AssetsSyncOperation.swift
@@ -29,7 +29,7 @@ public class SHAssetsSyncOperation: Operation, SHBackgroundOperationProtocol {
         var userIdsDescriptorsSet = Set<UserIdentifier>()
         for descriptor in descriptors {
             userIdsDescriptorsSet.insert(descriptor.sharingInfo.sharedByUserIdentifier)
-            descriptor.sharingInfo.sharedWithUserIdentifiersInGroup.keys.forEach({ userIdsDescriptorsSet.insert($0) })
+            descriptor.sharingInfo.groupIdsByRecipientUserIdentifier.keys.forEach({ userIdsDescriptorsSet.insert($0) })
         }
         return userIdsDescriptorsSet
     }

--- a/Sources/Safehill-Client/Tasks/Syncing/CachesSyncOperation.swift
+++ b/Sources/Safehill-Client/Tasks/Syncing/CachesSyncOperation.swift
@@ -27,7 +27,7 @@ public class SHCachesSyncOperation: Operation, SHBackgroundOperationProtocol {
         var userIdsDescriptorsSet = Set<UserIdentifier>()
         for descriptor in descriptors {
             userIdsDescriptorsSet.insert(descriptor.sharingInfo.sharedByUserIdentifier)
-            descriptor.sharingInfo.sharedWithUserIdentifiersInGroup.keys.forEach({ userIdsDescriptorsSet.insert($0) })
+            descriptor.sharingInfo.groupIdsByRecipientUserIdentifier.keys.forEach({ userIdsDescriptorsSet.insert($0) })
         }
         return userIdsDescriptorsSet
     }
@@ -164,7 +164,7 @@ public class SHCachesSyncOperation: Operation, SHBackgroundOperationProtocol {
                 let assetIdToUserIds = allRemoteDescriptors
                     .reduce([GlobalIdentifier: [any SHServerUser]]()) { partialResult, descriptor in
                         var result = partialResult
-                        var userIdList = Array(descriptor.sharingInfo.sharedWithUserIdentifiersInGroup.keys)
+                        var userIdList = Array(descriptor.sharingInfo.groupIdsByRecipientUserIdentifier.keys)
                         userIdList.append(descriptor.sharingInfo.sharedByUserIdentifier)
                         result[descriptor.globalIdentifier] = userIdList.compactMap({ remoteUsersById[$0] })
                         return result


### PR DESCRIPTION
* isPhotoMessageGroup in Descriptor GroupInfo
* `groupIdsByRecipientUserIdentifier` instead of `self.sharedWithUserIdentifiersInGroup` to hold info about group ids for asset+user