### PR TITLE
Bugfixing download operations

### DIFF
--- a/Sources/Safehill-Client/Controllers/LocalAssetStoreController.swift
+++ b/Sources/Safehill-Client/Controllers/LocalAssetStoreController.swift
@@ -70,8 +70,10 @@ public struct SHLocalAssetStoreController {
                     versions: versions,
                     receivedFrom: self.user
                 )
+                log.debug("[\(type(of: self))] successfully decrypted asset \(decryptedAsset.globalIdentifier)")
                 completionHandler(.success(decryptedAsset))
             } catch {
+                log.error("[\(type(of: self))] failed decrypting asset \(encryptedAsset.globalIdentifier): \(error.localizedDescription)")
                 completionHandler(.failure(error))
             }
         } else {
@@ -80,11 +82,13 @@ public struct SHLocalAssetStoreController {
             ) { result in
                 switch result {
                 case .failure(let error):
+                    log.error("[\(type(of: self))] failed to fetch user \(descriptor.sharingInfo.sharedByUserIdentifier) details for decrypting asset \(encryptedAsset.globalIdentifier): \(error.localizedDescription)")
                     completionHandler(.failure(error))
                 case .success(let usersDict):
                     guard usersDict.count == 1, let serverUser = usersDict.values.first,
                           serverUser.identifier == descriptor.sharingInfo.sharedByUserIdentifier
                     else {
+                        log.error("[\(type(of: self))] failed to fetch user details for decrypting asset \(encryptedAsset.globalIdentifier). No user \(descriptor.sharingInfo.sharedByUserIdentifier)")
                         completionHandler(.failure(SHBackgroundOperationError.unexpectedData(usersDict)))
                         return
                     }
@@ -95,8 +99,10 @@ public struct SHLocalAssetStoreController {
                             versions: versions,
                             receivedFrom: serverUser
                         )
+                        log.debug("[\(type(of: self))] successfully decrypted asset \(decryptedAsset.globalIdentifier)")
                         completionHandler(.success(decryptedAsset))
                     } catch {
+                        log.error("[\(type(of: self))] failed decrypting asset \(encryptedAsset.globalIdentifier): \(error.localizedDescription)")
                         completionHandler(.failure(error))
                     }
                 }

--- a/Sources/Safehill-Client/Network/LocalServer.swift
+++ b/Sources/Safehill-Client/Network/LocalServer.swift
@@ -768,7 +768,7 @@ struct LocalServer : SHServerAPI {
                 continue
             }
             
-            if Set(sharedWithUsersInGroup.values).count != groupInfoById.count || groupInfoById.values.contains(where: { $0.createdAt == nil }) {
+            if Set(sharedWithUsersInGroup.values).count > groupInfoById.count || groupInfoById.values.contains(where: { $0.createdAt == nil }) {
                 log.error("some group information (or the creation date of such groups) is missing. \(groupInfoById.map({ ($0.key, $0.value.name, $0.value.createdAt) }))")
             }
             

--- a/Sources/Safehill-Client/Network/LocalServer.swift
+++ b/Sources/Safehill-Client/Network/LocalServer.swift
@@ -1023,7 +1023,7 @@ struct LocalServer : SHServerAPI {
             assetCondition = c
         }
         
-        log.debug("feching local server asset versions \(versions.map({ $0.rawValue })) chunk \(index) \(String(describing: assetIdentifiersChunk[index]))")
+        log.debug("feching local server asset versions \(versions.map({ $0.rawValue })) chunk \(index) \(String(describing: assetIdentifiersChunk))")
         
         assetStore.dictionaryRepresentation(forKeysMatching: prefixCondition.and(assetCondition)) {
             (result: Result) in


### PR DESCRIPTION
* [Carry filtered out incomplete descriptors across remote download cycles](https://github.com/Safehill/Safehill-Client/commit/a3d666a940e098e2d8c5334cbc53abc2f613d31f)
* [Notify delegates about decryption failures in local download](https://github.com/Safehill/Safehill-Client/commit/3e41bda5a18a83aa95a1e7d9fb1b5b02e3d46271)  : Balance the didReceive with didComplete + didFail